### PR TITLE
Fix crashes on current ONI builds (U59): API drift + serialization safeguards

### DIFF
--- a/OniExtract2024/BaseExport.cs
+++ b/OniExtract2024/BaseExport.cs
@@ -43,7 +43,103 @@ namespace OniExtract2024
             JsonSerializerSettings settings = new JsonSerializerSettings();
             settings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
             settings.Formatting = Formatting.Indented;
+            // ONI builds after 623230: serializing live Unity/game component graphs can hit
+            // property getters that throw on prefab templates (e.g. a null TransformHandle),
+            // which aborted the whole dump. Skip any member that throws and keep going so the
+            // serializable data (rates, recipes, elements, etc.) still gets written.
+            settings.Error = (sender, args) =>
+            {
+                args.ErrorContext.Handled = true;
+            };
+            // Do NOT recurse into live UnityEngine.Object graphs (Material/GameObject/Component/
+            // KAnimFile/Transform...). On ONI builds after 623230 those getters can throw
+            // (null TransformHandle) and the graph is huge/cyclic enough to hang the dump.
+            // Emit just the object name. All data we need is already copied into plain fields.
+            settings.Converters.Add(new UnityObjectJsonConverter());
+            // Serialize Element as scalar fields only — skips the substance/material/anim graph
+            // that StackOverflows. Keeps the physical properties we actually want.
+            settings.Converters.Add(new ElementJsonConverter());
             File.WriteAllText(Path.Combine(GetDatabaseLocation(), ExportFileName + ".json"), JsonConvert.SerializeObject(this, settings));
+        }
+    }
+
+    // Serializes any UnityEngine.Object as just its name (or null) and never recurses into it.
+    // Prevents both the null-TransformHandle NullReferenceException and the deep/cyclic graph
+    // traversal that hung the Elements/Building/Entity dumps on ONI builds after 623230.
+    public class UnityObjectJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(System.Type objectType)
+        {
+            return typeof(UnityEngine.Object).IsAssignableFrom(objectType);
+        }
+
+        public override bool CanRead { get { return false; } }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            UnityEngine.Object uo = value as UnityEngine.Object;
+            // Unity overloads == so this also catches destroyed / "fake null" objects.
+            if (object.ReferenceEquals(uo, null) || uo == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+            string n = null;
+            try { n = uo.name; } catch { }
+            writer.WriteValue(n);
+        }
+
+        public override object ReadJson(JsonReader reader, System.Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+
+    // Serializes an Element as ONLY its scalar members (primitives, enums, strings, Tags),
+    // skipping reference-typed members like `substance` whose deep material/anim graph
+    // stack-overflows the serializer. Reflection-based so it survives game field renames.
+    public class ElementJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(System.Type t) { return t == typeof(Element); }
+        public override bool CanRead { get { return false; } }
+
+        public override void WriteJson(JsonWriter w, object value, JsonSerializer s)
+        {
+            if (value == null) { w.WriteNull(); return; }
+            var t = value.GetType();
+            var flags = System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance;
+            var seen = new System.Collections.Generic.HashSet<string>();
+            w.WriteStartObject();
+            foreach (var f in t.GetFields(flags))
+                WriteMember(w, seen, f.Name, SafeGet(delegate { return f.GetValue(value); }), f.FieldType);
+            foreach (var p in t.GetProperties(flags))
+            {
+                if (!p.CanRead || p.GetIndexParameters().Length > 0) continue;
+                var prop = p;
+                WriteMember(w, seen, prop.Name, SafeGet(delegate { return prop.GetValue(value, null); }), prop.PropertyType);
+            }
+            w.WriteEndObject();
+        }
+
+        static object SafeGet(System.Func<object> g) { try { return g(); } catch { return null; } }
+
+        static void WriteMember(JsonWriter w, System.Collections.Generic.HashSet<string> seen, string name, object v, System.Type ft)
+        {
+            if (!seen.Add(name)) return;
+            if (ft == typeof(Tag)) { w.WritePropertyName(name); w.WriteValue(v == null ? null : ((Tag)v).Name); return; }
+            if (ft.IsEnum) { w.WritePropertyName(name); w.WriteValue(v == null ? null : v.ToString()); return; }
+            if (ft.IsPrimitive || ft == typeof(string) || ft == typeof(decimal))
+            {
+                w.WritePropertyName(name);
+                w.WriteValue(v);
+                return;
+            }
+            seen.Remove(name); // not written — allow a later field/prop of same name to try
+        }
+
+        public override object ReadJson(JsonReader reader, System.Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/OniExtract2024/model/OutManualDeliveryKG.cs
+++ b/OniExtract2024/model/OutManualDeliveryKG.cs
@@ -3,9 +3,9 @@ namespace OniExtract2024
 {
     public class OutManualDeliveryKG
     {
-        public OutStorage storage;        
-        public Tag requestedItemTag;
-        public Tag[] forbiddenTags;        
+        public OutStorage storage;
+        // requestedItemTag removed from ManualDeliveryKG in ONI builds after 623230. Dropped (not ledger-relevant).
+        public Tag[] forbiddenTags;
         public float capacity = 100f;        
         public float refillMass = 10f;        
         public float MinimumMass = 10f;
@@ -28,7 +28,6 @@ namespace OniExtract2024
             {
                 this.storage = null;
             }
-            this.requestedItemTag = obj.requestedItemTag;
             this.forbiddenTags = obj.ForbiddenTags;
             this.capacity = obj.Capacity;
             this.refillMass = obj.refillMass;

--- a/OniExtract2024/model/OutNavigator.cs
+++ b/OniExtract2024/model/OutNavigator.cs
@@ -11,11 +11,9 @@ namespace OniExtract2024
         public Dictionary<NavType, int> distanceTravelledByNavType;
         public bool executePathProbeTaskAsync;
         public PathFinder.PotentialPath.Flags flags;
-        public int maxProbingRadius;
         public string NavGridName;
         public PathFinder.Path path;
-        public PathProber PathProber;
-        public PathProbeTask pathProbeTask;
+        // PathProber became a static class and PathProbeTask was removed in ONI builds after 623230. Both dropped (pathfinding internals, unused by the ledger).
         public Grid.SceneLayer sceneLayer = Grid.SceneLayer.Move;
         public TransitionDriver transitionDriver;
         public bool updateProber;
@@ -28,10 +26,8 @@ namespace OniExtract2024
             this.distanceTravelledByNavType = obj.distanceTravelledByNavType;
             this.executePathProbeTaskAsync = obj.executePathProbeTaskAsync;
             this.flags = obj.flags;
-            this.maxProbingRadius = obj.maxProbingRadius;
             this.NavGridName = obj.NavGridName;
             this.path = obj.path;
-            this.pathProbeTask = obj.pathProbeTask;
             this.sceneLayer = obj.sceneLayer;
             this.transitionDriver = obj.transitionDriver;
             this.updateProber = obj.updateProber;

--- a/OniExtract2024/model/OutPickupable.cs
+++ b/OniExtract2024/model/OutPickupable.cs
@@ -4,7 +4,6 @@ namespace OniExtract2024
     public class OutPickupable
     {
         public bool IsEntombed;
-        public float MinTakeAmount;
         public bool prevent_absorb_until_store;
         public OutPrimaryElement PrimaryElement;
         public float ReservedAmount;
@@ -24,7 +23,7 @@ namespace OniExtract2024
         public OutPickupable(Pickupable obj)
         {
             this.IsEntombed = obj.IsEntombed;
-            this.MinTakeAmount = obj.MinTakeAmount;
+            // MinTakeAmount removed from Pickupable in ONI builds after 623230 (MissingMethodException). Field dropped.
             this.prevent_absorb_until_store = obj.prevent_absorb_until_stored;
             if(obj.PrimaryElement != null )
             {


### PR DESCRIPTION
## What

Makes OniExtract2024 load and export again on current ONI builds. I verified a full clean dump (to the main menu, no crash) on **`U59-737790-SCRPAND`** with all DLCs active. Without these changes the mod fails to complete on that build.

There are three independent failure modes, fixed separately:

### 1. `MissingMethodException` — game APIs removed/changed since build 623230
- `Pickupable.MinTakeAmount` (removed)
- `Navigator.PathProber` (now a static class), `Navigator.PathProbeTask` (removed), `Navigator.maxProbingRadius` (removed)
- `ManualDeliveryKG.requestedItemTag` (removed)

Dropped these fields from the corresponding `Out*` models (`OutPickupable`, `OutNavigator`, `OutManualDeliveryKG`). They're not needed for the exported data.

### 2. `NullReferenceException` / hang while serializing live component graphs
On this build, serializing some live components reaches a getter that throws (e.g. *"The TransformHandle object is null…"*), which aborted the whole dump. Hardened `BaseExport.ExportJsonFile`:
- a `JsonSerializerSettings.Error` handler that marks per-member errors handled (skip the bad member, keep going), and
- **`UnityObjectJsonConverter`** — serializes any `UnityEngine.Object` as just its `name` (or null) and never recurses into the live Unity object graph. This both avoids the throwing getters and prevents the graph from blowing up.

### 3. `StackOverflowException` (silent process exit) on the Elements dump
`ExportElement` serializes raw `Element` objects, which drag in `substance` → `Material`/anim and a deep cyclic graph; on U59 this overflows the stack and the game exits with no managed error. **`ElementJsonConverter`** serializes `Element` as scalar members only (primitives/enums/strings/`Tag`), skipping the reference graph. Reflection-based, so it tolerates field renames.

## Testing

Built with the VS2022 Roslyn compiler against the live game DLLs and ran in-game. Full dump completes; `building.json` I/O (e.g. Electrolyzer: water 1.0 → O₂ 0.888 + H₂ 0.112 kg/s), `recipe.json`, `entities.json`, and `elements.json` all look correct against current values.

## Note on the Db and UI-sprite exports

Full disclosure: in my own build I **disabled the `Db` and `UI Sprite` exports** because they were causing silent shutdowns (and the UI-sprite dump writes thousands of PNGs I didn't need). I **did not** include those disables in this PR — they'd regress functionality for others, and both are already toggleable via the mod's options. The serialization safeguards above (the `Error` handler + `UnityObjectJsonConverter`) very likely fix `Db` as well, but I **haven't validated `Db`/UI-sprite under these changes**, so I'm flagging it: if someone hits a shutdown on those two on a current build, they may need the same treatment (or just toggle them off).

Happy to adjust anything.
